### PR TITLE
Explicitly provide default scroll behavior value

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,6 +6,47 @@ const tailwindJS = join(__dirname, 'tailwind.js')
 module.exports = {
   mode: 'spa',
 
+  router: {
+    // According to the Nuxt docs, this is the default value of scrollBehavior:
+    // https://nuxtjs.org/api/configuration-router#scrollbehavior
+    // Without this explicitly provided, though, using the back button in
+    // Chrome does not work when navigating different sections of the page.
+    scrollBehavior: function(to, from, savedPosition) {
+      // if the returned position is falsy or an empty object,
+      // will retain current scroll position.
+      let position = false
+
+      // if no children detected
+      if (to.matched.length < 2) {
+        // scroll to the top of the page
+        position = { x: 0, y: 0 }
+      } else if (
+        to.matched.some(r => r.components.default.options.scrollToTop)
+      ) {
+        // if one of the children has scrollToTop option set to true
+        position = { x: 0, y: 0 }
+      }
+
+      // savedPosition is only available for popstate navigations (back button)
+      if (savedPosition) {
+        position = savedPosition
+      }
+
+      return new Promise(resolve => {
+        // wait for the out transition to complete (if necessary)
+        window.$nuxt.$once('triggerScroll', () => {
+          // coords will be used if no selector is provided,
+          // or if the selector didn't match any element.
+          if (to.hash && document.querySelector(to.hash)) {
+            // scroll to anchor by returning the selector
+            position = { selector: to.hash }
+          }
+          resolve(position)
+        })
+      })
+    }
+  },
+
   /*
   ** Headers of the page
   */


### PR DESCRIPTION
Explicitly providing the value of `scrollBehavior` provided in the [Nuxt docs](https://nuxtjs.org/api/configuration-router#scrollbehavior) appears to resolve the issue with back button navigation in Chrome.

Maybe the actual default value in the Nuxt code is not what appears in the documentation and has a bug in it? 🤷‍♀ 

Anyway, this fixes #91.