### PR TITLE
Update Lansing JVM User Group URL

### DIFF
--- a/config/meetups.js
+++ b/config/meetups.js
@@ -123,7 +123,7 @@ export default [
       'One of the most popular languages in the world with an incredibly rich ecosystem.',
     iconSet: 'fab',
     iconName: 'java',
-      url: 'https://www.meetup.com/Lansing-JVM-User-Group/',
+    url: 'https://www.meetup.com/Lansing-JVM-User-Group/',
     subheading: '2nd Thursday'
   },
   // 3rd Tuesday

--- a/config/meetups.js
+++ b/config/meetups.js
@@ -123,7 +123,7 @@ export default [
       'One of the most popular languages in the world with an incredibly rich ecosystem.',
     iconSet: 'fab',
     iconName: 'java',
-    url: 'https://sites.google.com/site/greaterlansingjug/',
+      url: 'https://www.meetup.com/Lansing-JVM-User-Group/',
     subheading: '2nd Thursday'
   },
   // 3rd Tuesday


### PR DESCRIPTION
* Update the URL for 'Java' to the Lansing JVM User Group Meetup group URL, 'https://www.meetup.com/Lansing-JVM-User-Group/'