### PR TITLE
Groups with multiple same day events show on one line (fixes #103)

### DIFF
--- a/components/calendar--event.vue
+++ b/components/calendar--event.vue
@@ -1,0 +1,125 @@
+<template>
+  <li
+    v-popover="{
+      name: firstEvent.id
+    }"
+    class="
+      block list-none mx-1 py-2 border-t border-blue
+      hover:bg-blue-lightest
+    "
+  >
+    <a
+      :href="firstEvent.url"
+      class="w-full block no-underline text-blue-darker"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      <span v-if="eventGroup(firstEvent)">
+        <logo
+          v-if="eventGroup(firstEvent)"
+          :icon-set="eventGroup(firstEvent).iconSet"
+          :icon-name="eventGroup(firstEvent).iconName"
+          :icon-text="eventGroup(firstEvent).iconText"
+          class="inline-block"
+        />
+      </span>
+      {{ formatTimeOfEvent(firstEvent) }}
+      <div class="mt-1">{{ eventGroup(firstEvent).name }}</div>
+      <div
+        v-if="additionalEvents.length > 0"
+        class="text-sm">
+        <i>also:
+          <span
+            v-for="(event, index) in additionalEvents"
+            :key="event.id">
+            <span v-if="index == 0">
+              {{ formatTimeOfEvent(event) }}
+            </span>
+            <span v-else>
+              , {{ formatTimeOfEvent(event) }}
+            </span>
+          </span>
+        </i>
+      </div>
+    </a>
+    <transition
+      enter-active-class="transition-opacity"
+      enter-class="opacity-0"
+      leave-active-class="transition-opacity"
+      leave-to-class="opacity-0"
+    >
+      <popover
+        :name="firstEvent.id"
+        :width="225"
+        event="hover"
+        class="
+          text-blue-darker border border-blue shadow-md -mt-2 hidden
+        "
+      >
+        <ul class="m-0 p-0">
+          <li
+            v-for="detail in allEvents(firstEvent, additionalEvents)"
+            :key="detail.id"
+            class="
+              block list-none mx-1 py-2 border-t border-blue
+              hover:bg-blue-lightest
+            "
+          >
+            <a
+              :href="detail.url"
+              class="w-full block no-underline text-blue-darker"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {{ formatTimeOfEvent(detail) }} {{ detail.name }}
+            </a>
+          </li>
+        </ul>
+      </popover>
+    </transition>
+  </li>
+</template>
+
+<script>
+import { format as formatDate } from 'date-fns'
+import groupForEvent from '~/utils/group-for-event'
+import logo from '~/components/logo--extra-small'
+
+export default {
+  components: {
+    logo
+  },
+  props: {
+    firstEvent: {
+      type: Object,
+      required: true
+    },
+    additionalEvents: {
+      type: Array,
+      required: true
+    }
+  },
+  data() {
+    return {
+      open: false
+    }
+  },
+  methods: {
+    allEvents(firstEvent, additionalEvents) {
+      var firstArray = [firstEvent]
+      return firstArray.concat(additionalEvents)
+    },
+    eventGroup(event) {
+      return groupForEvent(event, this.$store.state.groups.all)
+    },
+    formatTimeOfEvent(event) {
+      const startMinutes = formatDate(event.startTime, 'm')
+      return formatDate(
+        event.startTime,
+        startMinutes === '0' ? 'h a' : 'h:mm a'
+      )
+    },
+    formatDate
+  }
+}
+</script>

--- a/components/calendar--event.vue
+++ b/components/calendar--event.vue
@@ -28,18 +28,14 @@
       <div
         v-if="additionalEvents.length > 0"
         class="text-sm">
-        <i>also:
+        <aside class="italic">also:
           <span
             v-for="(event, index) in additionalEvents"
             :key="event.id">
-            <span v-if="index == 0">
-              {{ formatTimeOfEvent(event) }}
-            </span>
-            <span v-else>
-              , {{ formatTimeOfEvent(event) }}
-            </span>
+            <span v-if="index == 0">{{ formatTimeOfEvent(event) }}</span>
+            <span v-else>, {{ formatTimeOfEvent(event) }}</span>
           </span>
-        </i>
+        </aside>
       </div>
     </a>
     <transition
@@ -58,11 +54,13 @@
       >
         <ul class="m-0 p-0">
           <li
-            v-for="detail in allEvents(firstEvent, additionalEvents)"
+            v-for="(detail, index) in allEvents(firstEvent, additionalEvents)"
             :key="detail.id"
+            :class="{
+              'border-t': index > 0
+            }"
             class="
-              block list-none mx-1 py-2 border-t border-blue
-              hover:bg-blue-lightest
+              block list-none mx-1 py-2 border-blue hover:bg-blue-lightest
             "
           >
             <a
@@ -71,7 +69,7 @@
               target="_blank"
               rel="noreferrer noopener"
             >
-              {{ formatTimeOfEvent(detail) }} {{ detail.name }}
+              <span v-if="additionalEvents.length > 0">{{ formatTimeOfEvent(detail) }} </span>{{ detail.name }}
             </a>
           </li>
         </ul>

--- a/components/event-calendar.vue
+++ b/components/event-calendar.vue
@@ -33,8 +33,8 @@
             <calendar-event
               v-for="groupEvents in eventsOnDay(day)"
               :key="groupEvents.id"
-              :first-event="groupsFirstEventOnDay(groupEvents)"
-              :additional-events="otherEventsForGroupOnDay(groupEvents)"
+              :first-event="firstEvent(groupEvents)"
+              :additional-events="otherEvents(groupEvents)"
             />
           </ul>
         </div>
@@ -93,12 +93,12 @@ export default {
   methods: {
     eventsOnDay(day) {
       // get the events on this day
-      var events = this.events.filter(event =>
+      const events = this.events.filter(event =>
         isSameDay(new Date(event.startTime), day)
       )
 
-      var results = events.reduce(function(acc, obj) {
-        var key = obj['group']
+      const results = events.reduce(function(acc, obj) {
+        const key = obj['group']
 
         if (!acc[key]) {
           acc[key] = []
@@ -110,10 +110,10 @@ export default {
 
       return results
     },
-    groupsFirstEventOnDay(groupEvents) {
+    firstEvent(groupEvents) {
       return groupEvents[0]
     },
-    otherEventsForGroupOnDay(groupEvents) {
+    otherEvents(groupEvents) {
       return groupEvents.slice(1, groupEvents.length)
     },
     formatDayOfMonth(day) {


### PR DESCRIPTION
Now if on the same day a group has multiple events they will be combined as described in the issue.   Split out the calendar event to a new component so that the calendar code wasn't as messy. Not really a front end / UI person so any thoughts on how to improve would be appreciated.