### PR TITLE
Added 'font-display: swap;' to ensure text remains visible during web font load.

### DIFF
--- a/assets/font-lansing-codes/font-lansing-codes.css
+++ b/assets/font-lansing-codes/font-lansing-codes.css
@@ -7,12 +7,14 @@
        url("./font-lansing-codes.svg#font-lansing-codes") format("svg");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   @font-face {
     font-family: "FontLansingCodes";
     src: url("./font-lansing-codes.svg#font-lansing-codes") format("svg");
+    font-display: swap;
   }
 }
 


### PR DESCRIPTION
https://github.com/lansingcodes/www/issues/147

I was only able to solve 1 out of 2 violations, but I did create a follow-up for the other:
https://github.com/lansingcodes/www/issues/155