### PR TITLE
Preconnect and preload web fonts

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,9 +84,26 @@ module.exports = {
       { rel: 'image_src', type: 'image/png', href: '/favicon.ico?v=1' },
       { rel: 'icon', type: 'image/png', href: '/favicon.ico?v=1' },
       {
+        rel: 'preload',
+        as: 'style',
+        href:
+          'https://cdnjs.cloudflare.com/ajax/libs/font-mfizz/2.4.1/font-mfizz.min.css'
+      },
+      {
         rel: 'stylesheet',
         href:
           'https://cdnjs.cloudflare.com/ajax/libs/font-mfizz/2.4.1/font-mfizz.min.css'
+      },
+      {
+        rel: 'preconnect',
+        href: 'https://fonts.gstatic.com',
+        crossorigin: true
+      },
+      {
+        rel: 'preload',
+        as: 'style',
+        href:
+          'https://fonts.googleapis.com/css?family=Montserrat:500,700&display=swap'
       },
       {
         rel: 'stylesheet',


### PR DESCRIPTION
Fixes #146

1. Use `preload` to start downloading the web fonts earlier in the page lifecycle ([more info](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload))
2. Use `preconnect` to connect to Google's CDN early instead of waiting for the redirect/handshake is requested ([more info](https://www.cdnplanet.com/blog/faster-google-webfonts-preconnect))
