### PR TITLE
Account for longer periods with no events

### DIFF
--- a/components/event-calendar.vue
+++ b/components/event-calendar.vue
@@ -50,14 +50,14 @@ import {
   isBefore,
   isAfter,
   addDays,
+  addWeeks,
   isSameDay,
   format as formatDate
 } from 'date-fns'
 import chunk from 'lodash/chunk'
-import formatReadableDateTime from '~/utils/format-readable-date-time'
-import groupForEvent from '~/utils/group-for-event'
 import simplifiedName from '~/utils/simplified-name'
 import calendarEvent from '~/components/calendar--event'
+import maxCalendarWeeks from '~/config/max-calendar-weeks'
 
 export default {
   components: {
@@ -77,7 +77,11 @@ export default {
     },
     endDate() {
       const lastEvent = this.events[this.events.length - 1]
-      return endOfWeek(lastEvent.startTime)
+      return endOfWeek(
+        lastEvent
+          ? lastEvent.startTime
+          : endOfWeek(addWeeks(this.startDate, maxCalendarWeeks - 1))
+      )
     },
     calendar() {
       const dates = []

--- a/components/section-heading.vue
+++ b/components/section-heading.vue
@@ -64,8 +64,8 @@ export default {
       default: ''
     },
     subpage: {
-      type: Boolean,
-      default: false
+      type: String,
+      default: undefined
     },
     subpageLink: {
       type: String,

--- a/components/welcome.vue
+++ b/components/welcome.vue
@@ -87,20 +87,49 @@
             class="lc-event-description mb-6"
             v-html="cleanEventDescription(nextEvent.description)"
           />
+          <div class="text-center">
+            <a
+              :href="nextEvent.url"
+              class="
+                inline-block bg-white no-underline
+                text-blue font-bold uppercase text-center py-4 mt-2 px-8
+                min-w-24 rounded-full
+              "
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Learn More and RSVP
+            </a>
+          </div>
         </div>
-        <div class="text-center">
-          <a
-            :href="nextEvent.url"
-            class="
-              inline-block bg-white no-underline
-              text-blue font-bold uppercase text-center py-4 mt-2 px-8
-              min-w-24 rounded-full
-            "
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            Learn More and RSVP
-          </a>
+        <div
+          v-else
+          class="text-left font-normal"
+        >
+          <div class="flex flex-no-wrap items-center mb-2 min-h-12">
+            <logo
+              icon-set="far"
+              icon-name="grin-beam-sweat"
+              class="mr-3"
+            />
+            <h3 class="font-bold">
+              Well, this is awkward!
+            </h3>
+          </div>
+          <div class="lc-event-description my-6 leading-tight">
+            <p>
+              There don't appear to be any upcoming events on the calendar for
+              the next few weeks. It may be a slow time of the year or it could
+              be a mistake.
+            </p>
+            <p>
+              Check back in a few days or ask about it in Slack
+              and we'll get this cleared up for you soon.
+            </p>
+            <p>
+              Sorry we couldn't help you find what you're looking for!
+            </p>
+          </div>
         </div>
       </section>
     </div>
@@ -108,7 +137,6 @@
 </template>
 
 <script>
-import { format } from 'date-fns'
 import sectionHeading from '~/components/section-heading'
 import logo from '~/components/logo--small'
 import groupForEvent from '~/utils/group-for-event'
@@ -137,7 +165,7 @@ export default {
         {
           name: 'Groups',
           href: '#meetups',
-          iconSet: ['far', 'handshake']
+          iconSet: ['fas', 'user-friends']
         },
         {
           name: 'Resources',
@@ -160,7 +188,7 @@ export default {
   computed: {
     nextEvent() {
       var upcoming = this.$store.state.events.upcoming.filter(
-        event => event.startTime > Date.now()
+        event => event && event.startTime > Date.now()
       )
       return upcoming[0]
     },

--- a/config/max-calendar-weeks.js
+++ b/config/max-calendar-weeks.js
@@ -1,0 +1,2 @@
+// Maximum number of weeks to show on the calendar
+export default 4

--- a/plugins/font-awesome.js
+++ b/plugins/font-awesome.js
@@ -19,11 +19,11 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 // https://fontawesome.com/icons?d=gallery&s=regular&m=free
 import {
   faCalendarAlt,
-  faHandshake,
+  faGrinBeamSweat,
   faThumbsUp
 } from '@fortawesome/free-regular-svg-icons'
 
-library.add(faCalendarAlt, faHandshake, faThumbsUp)
+library.add(faCalendarAlt, faGrinBeamSweat, faThumbsUp)
 
 // free SOLID icon set (fas)
 // https://fontawesome.com/icons?d=gallery&s=solid&m=free
@@ -51,6 +51,7 @@ import {
   faTimes,
   faUnlockAlt,
   faUserCircle,
+  faUserFriends,
   faUsers
 } from '@fortawesome/free-solid-svg-icons'
 
@@ -78,6 +79,7 @@ library.add(
   faTimes,
   faUnlockAlt,
   faUserCircle,
+  faUserFriends,
   faUsers
 )
 

--- a/store/events.js
+++ b/store/events.js
@@ -1,8 +1,7 @@
 import { firestoreAction } from 'vuexfire'
 import firestore from '~/utils/firestore'
 import { startOfDay, addWeeks, endOfDay, endOfWeek } from 'date-fns'
-
-const weeksAvailable = 4
+import weeksAvailable from '~/config/max-calendar-weeks'
 
 export const state = () => ({
   upcoming: []


### PR DESCRIPTION
1. Explain on the Next Event card that there isn't an event in the next few weeks

2. Show a 4-week calendar even if there aren't any events

3. Handshakes are so 2019, let's be friends instead

4. Make the section heading subtitle a string because that's what it is