### PR TITLE
#185 Changing Slack URL to always go to the redirect

### DIFF
--- a/config/urls.json
+++ b/config/urls.json
@@ -2,6 +2,6 @@
   "email": "mailto:lansingcodes@gmail.com",
   "facebook": "https://www.facebook.com/LansingCodes/",
   "github": "https://github.com/lansingcodes/",
-  "slack": "https://lansingcodes-slackin.herokuapp.com/",
+  "slack": "https://slack.lansing.codes/",
   "twitter": "https://twitter.com/lansingcodes"
 }


### PR DESCRIPTION
In order to update the self-invite process for the Lansing Codes Slack Workspace, this will change the Slack link to go to the [slackin-redirect](https://github.com/lansingcodes/slackin-redirect), since the new process requires the "real" URL to be updated periodically. Using the redirect from the Lansing Codes homepage ensures that we only need to update the invite URL in [slackin-redirect](https://github.com/lansingcodes/slackin-redirect).