### PR TITLE
fixes related to #213

### DIFF
--- a/components/welcome.vue
+++ b/components/welcome.vue
@@ -56,15 +56,19 @@
           </div>
           <p class="flex flex-wrap justify-between text-sm mb-4 mt-0">
             <span class="mb-1 mr-2">
-              {{ formatReadableDateTime(nextEvent.startTime) }}
+              {{ timeForNextEvent }}
             </span>
             <span v-if="nextEvent.venue">
               {{ nextEvent.venue }}
             </span>
           </p>
-          <div class="lc-event-description mb-6">
-            {{ cleanEventDescription(nextEvent.description) }}
-          </div>
+          <!-- ok to disable the v-html check below because we've sanitized the input already -->
+          <!-- // eslint-disable-next-line vue/no-v-html -->
+          <div
+            class="lc-event-description mb-6"
+            v-html="boldMarkdownToHtml(safeDescriptionForNextEvent)"
+          />
+          <!-- also can't get rid of the v-html warning above because prettier -->
           <div class="text-center">
             <a
               :href="nextEvent.url"
@@ -105,6 +109,7 @@ import logo from '~/components/logo--small'
 import groupForEvent from '~/utils/group-for-event'
 import formatReadableDateTime from '~/utils/format-readable-date-time'
 import cleanEventDescription from '~/utils/clean-event-description'
+import boldMarkdownToHtml from '../utils/bold-markdown-to-html'
 import urls from '~/config/urls.json'
 
 export default {
@@ -158,10 +163,15 @@ export default {
     groupForNextEvent() {
       return groupForEvent(this.nextEvent, this.$store.state.groups.all)
     },
+    safeDescriptionForNextEvent() {
+      return cleanEventDescription(this.nextEvent.description)
+    },
+    timeForNextEvent() {
+      return formatReadableDateTime(this.nextEvent.startTime)
+    },
   },
   methods: {
-    formatReadableDateTime,
-    cleanEventDescription,
+    boldMarkdownToHtml,
   },
 }
 </script>

--- a/utils/clean-event-description.js
+++ b/utils/clean-event-description.js
@@ -17,8 +17,6 @@ export default (description) => {
   newDescription = newDescription.replace(/(---)(.*)/g, '')
   // Trim whitespace
   newDescription = newDescription.trim()
-  // Replace bold markdown with proper Tailwind markup
-  newDescription = boldMarkdownToHTML(newDescription)
   // Re-add the trailing ... characters
   newDescription = newDescription.concat('...')
   return newDescription


### PR DESCRIPTION
* extracted bolding markdown from cleaning the event description and clearly adding it into the event rendering
* see #220 for even more markdown improvements

Sorry, @MegTheDev that this was such a pain 😬 

@zowiebeha in the interest of single responsibility principle, I removed your `bold-markdown-to-html` from the `clean-event-description` and instead just used it directly in the component during rendering. Since it is generating html, I wanted to be clear that the XSS vulnerability I was fixing would still be fixed since the description wasn't being converted to HTML until it was rendering on the page. I hope that makes sense. Anyway, that's why I added you as a reviewer. Thanks for also making #220 - that's gonna be helpful all around, but then may also require us to go back and use `v-html` again... OR we could just upgrade/rewrite things before then, haha)